### PR TITLE
Fix COMP/SITE that were provided with incorrect arguments

### DIFF
--- a/riocore/generator/pins/lpf/pins.py
+++ b/riocore/generator/pins/lpf/pins.py
@@ -22,16 +22,16 @@ class Pins:
                 if pin_config["varname"] == "USRMCLK":
                     data.append(f"# this pin ({pin_config['pin']}) is not available in the lpf file, have to use the USRMCLK primitive in the verilog")
                     continue
-                data.append(f"LOCATE COMP \"{pin_config['pin']}\" SITE \"{pin_config['varname']}\";")
+                data.append(f"LOCATE COMP \"{pin_config['varname']}\" SITE \"{pin_config['pin']}\";")
 
                 iostandard = pin_config.get("iostandard", "LVCMOS33").upper()
                 drive = pin_config.get("drive", "4")
                 slew = pin_config.get("slew", "SLOW").upper()
 
                 if pin_config["direction"] == "input":
-                    data.append(f"IOBUF PORT \"{pin_config['pin']}\" IO_TYPE={iostandard};")
+                    data.append(f"IOBUF PORT \"{pin_config['varname']}\" IO_TYPE={iostandard};")
                 else:
-                    data.append(f"IOBUF PORT \"{pin_config['pin']}\" IO_TYPE={iostandard} DRIVE={drive} SLEWRATE={slew};")
+                    data.append(f"IOBUF PORT \"{pin_config['varname']}\" IO_TYPE={iostandard} DRIVE={drive} SLEWRATE={slew};")
 
             data.append("")
         data.append("")


### PR DESCRIPTION
While trying to test riocore on ecp5 I got an error about `sysclk_in not being constrained in pins file`. I don't know much about specifying constraints, but comparing pins.lpf generated by LinuxCNC-RIO and riocore, it became apparent to me COMP contained physical pin and SITE contained net-name (which should be the other way around).

This PR fixes this (at least my basic ECP5 config builds, haven't tested it on FPGA yet).