### PR TITLE
Add docker container that supports flashing for oss-cad-suite  toolchain

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,70 @@
+[LinuxCNC-RIO](https://github.com/multigcs/LinuxCNC-RIO)
+
+<h3 align="center">LinuxCNC-RIO Docker Container</h3>
+
+<div align="center">
+
+  [![License](https://img.shields.io/badge/license-GPL2-blue.svg)](/LICENSE)
+
+</div>
+
+---
+
+<p align="center"> Realtime-IO for LinuxCNC<br></p>
+
+## Table of Contents
+- [About](#about)
+- [Prerequisites](#prerequisites)
+- [Build and Run](#run)
+
+## About <a name = "about"></a>
+
+Docker allows you to contain all of the dependencies required to install and run riocore in one container, removing the complexity of differing setups and configurations of the host linux machine. This container will run the riocore gui, and should allow you to flash most fpga's that work similarly to the TangNano boards, and work with the oss-cad-suite (ie. work with the icestorm toolchain).
+
+The directory that you have cloned riocore into will be mounted in /workspace, allowing you to save your config and output there to be usable like normal outside of the container.
+
+The docker image will persist, making it fast and easy to rerun the gui for that period of time when you are rapidly iterating your config. You can always remove it if you need to reclaim the space:
+`docker rmi riocore`
+
+NOTE: this is only tested with a TangNano9k using the TangNano9k-icestorm board config on an Ubuntu 24.04 host.
+
+## Prerequisites <a name = "prerequisites"></a>
+
+You require 2 things:
+- A linux system. You probably already have this, since you're working with linuxcnc
+- Docker. Most distributions of linux including those for the Raspberry Pi distribute Docker through their package manager.
+  - Ubuntu/debian: sudo apt-get -y install docker.io
+  - It helps to have your user in the `docker` group.
+  - You should probably restart your computer so you ensure your user is in the correct group.
+
+Note: you only need to be running docker while you're working with the riocore ui or generator, you may disable it when you're done to save resources if you prefer.
+
+## Build and Run <a name = "run"></a>
+
+Get the codebase:
+
+via git:
+```
+git clone https://github.com/multigcs/riocore.git
+cd riocore
+```
+
+or download and extract the zip from the green "Code" button at https://github.com/multigcs/riocore
+
+build and run the conainer
+``` 
+make docker-run
+```
+
+if you already have a config file and wish to load it, you can do so in the first screen of the gui, or by passing it on the command line:
+```
+make docker-run CONFIG=./config.json
+```
+
+
+This will start riocore-setup as normal. Your riocore directory is mounted at /workspace/ so if you have already created a config, you can use the Load Existing Config button to load it from there. You can also save configs to that in later steps, and any generated and compiled output will be in /workspace/Output and you'll see it appear in your riocore directory outside of the container as well.
+
+NOTE: any files created by the container will be owned by root, so if that's a hassle, you may chown/chgrp it back to your user (mine is named cnc in this example, replace it with your user.):
+```
+cd /path/to/riocore/repo
+sudo chown -R cnc:cnc ./

--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,16 @@ docker-run-debian12_deb:
 	docker build -t riocore_debian12 -f dockerfiles/Dockerfile.debian12-min .
 	docker rm riocore_debian12 || true
 	docker run --net=host -v /tmp/.X12-unix:/tmp/.X12-unix -e DISPLAY=$$DISPLAY -v $$HOME/.Xauthority:/root/.Xauthority --name riocore_debian12 -v $(CURDIR):/usr/src/riocore -t -i riocore_debian12 /bin/bash -c "cd /usr/src/riocore; apt-get install --no-install-recommends -y ./debian-packages/python3-riocore_*-bookworm_all.deb; cd ~ ; PATH=$$PATH:/opt/oss-cad-suite/bin/ rio-setup"
+
+docker-run:
+	docker build -t riocore -f dockerfiles/Dockerfile.debian12-run .
+	xhost local:root || true
+	docker run --privileged --net=host -v /dev:/dev -v /tmp/.X11-unix:/tmp/.X11-unix -v $(CURDIR):/usr/src/riocore -v $(CURDIR):/workspace -e DISPLAY=$$DISPLAY -v $$HOME/.Xauthority:/root/.Xauthority --name riocore -t -i riocore /bin/bash -c "cd /usr/src/riocore; PATH=$$PATH:/opt/oss-cad-suite/bin/ PYTHONPATH=. bin/rio-setup $(CONFIG)"
+	docker rm -f riocore || true
+
+update:
+	git pull
+	git submodule update --init --recursive
+	make clean
+	docker rmi -f riocore || true
+	

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ git clone https://github.com/multigcs/riocore.git
 cd riocore
 ```
 
+Using a TangNano9k or other board supported by the open-cad-suite? Check out the docker setup for an easy to use all in one way to run the riocore ui and generator, including flashing: [DOCKER](DOCKER.md)
+
 make sure that the toolchain matching your fpga is in the path:
 ```
 export PATH=$PATH:/opt/oss-cad-suite/bin/

--- a/dockerfiles/Dockerfile.debian12-run
+++ b/dockerfiles/Dockerfile.debian12-run
@@ -1,0 +1,12 @@
+
+FROM debian:12
+
+RUN apt-get update
+RUN apt-get -y install wget tar python3 python3-pip python3-yaml python3-graphviz python3-pyqtgraph python3-pyqt5 python3-pyqt5.qtsvg python3-stdeb dh-python python3-pyqt5 python3-pyqt5.qtsvg make
+
+RUN (cd /opt/ && wget https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2024-09-03/oss-cad-suite-linux-x64-20240903.tgz && tar xzvpf oss-cad-suite-linux-x64-20240903.tgz)
+
+RUN mkdir /workspace
+
+CMD ["/bin/bash"]
+


### PR DESCRIPTION
I was trying to run riocore using the gateware toolchain on Ubuntu 24.04 but ran into some incompatibilities with libreadline that GW did not ship. I decided that instead of working around that, I'd make a docker container for icestorm instead. I then discovered you already had a container that worked pretty well, but couldn't flash the device on the host. 

I made a few quality of life improvements to hopefully help out the less linux savy users. I didn't see a way to easily switch toolchains so I included another boardconfig for the TangNano9k that has the toolchain switched to icestorm, as an example. If there's a better way to do this, please let me know!

Mounting a volume for the FTDI adapter inside the tang nano was required, hence the volume for /dev:/dev, and in order to do that, the container needs to be priviledged.

In order for the gui to work under more strict x sessions, xhost localhost:root was required (in the Makefile). I think this is probably safe enough for most people.