### PR TITLE
Update LinuxCNC.py

### DIFF
--- a/riocore/generator/LinuxCNC.py
+++ b/riocore/generator/LinuxCNC.py
@@ -3415,8 +3415,8 @@ class axis:
         elif halpin.endswith(".B"):
             cfgxml_data.append('      <on_color>"blue"</on_color>')
         else:
-            cfgxml_data.append('      <on_color>"green"</on_color>')
-        cfgxml_data.append('      <off_color>"black"</off_color>')
+            cfgxml_data.append('      <on_color>"yellow"</on_color>')
+        cfgxml_data.append('      <off_color>"red"</off_color>')
         cfgxml_data.append("    </led>")
         cfgxml_data.append("  </hbox>")
         return (f"pyvcp.{halpin}", cfgxml_data)


### PR DESCRIPTION

![Screenshot 2024-11-03 131905](https://github.com/user-attachments/assets/9ccf066b-0134-4503-a80d-8cd08938592b)
![Screenshot 2024-11-03 131923](https://github.com/user-attachments/assets/3f18219e-e755-4bd5-8cdb-e67a69c7c879)
This shows the inputs in the Panel in the same yellow, and almost the same red as in the Hal Configuration. This makes it more Linuxcnc standard see if the signal is On or Off.