### PR TITLE
Format tab bar to help MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ cython_debug/
 riocore/toolchains.json
 *-test.json
 
+# Mac Nonsense
+.DS_Store

--- a/bin/rio-setup
+++ b/bin/rio-setup
@@ -41,6 +41,7 @@ from riocore.widgets import (
     STYLESHEET,
     STYLESHEET_CHECKBOX_GREEN_RED,
     STYLESHEET_BUTTON,
+    STYLESHEET_TABBAR,
 )
 
 
@@ -1357,6 +1358,7 @@ class WinForm(QWidget):
             self.vcp = None
 
         self.tabwidget = QTabWidget()
+        self.tabwidget.setStyleSheet(STYLESHEET_TABBAR)
         splitter.addWidget(self.tabwidget)
 
         self.gateware_hash = None
@@ -3331,6 +3333,7 @@ class WinForm(QWidget):
             joint_options[pkey]["default"] = value
 
         joint_tabs = QTabWidget()
+        joint_tabs.setStyleSheet(STYLESHEET_TABBAR)
 
         general_layout = QVBoxLayout()
         label = QLabel("Joint-Setup")
@@ -3667,6 +3670,7 @@ class WinForm(QWidget):
             dialog_buttonBox.addButton(remove_button, QDialogButtonBox.ActionRole)
 
         tab_widget = QTabWidget()
+        tab_widget.setStyleSheet(STYLESHEET_TABBAR)
 
         if is_new and plugin_instance.TYPE == "joint":
             if "position" in plugin_instance.SIGNALS:

--- a/riocore/widgets.py
+++ b/riocore/widgets.py
@@ -35,6 +35,30 @@ STYLESHEET_CHECKBOX_GREEN_RED = """
     }
 """
 
+# MacOS tabs default to white backgrounds, making them unreadable without more styling. 
+STYLESHEET_TABBAR = """
+    QTabBar::tab {
+        background-color: #333333;
+        border-style: solid;
+        border-color: #222222;
+        border-width: 2px 1px 0px;
+        color: white;
+        padding: 5px 10px;
+        margin: 5px 1px 0px;
+    }
+
+    QTabBar::tab:selected {
+        background-color: #444444;
+        border-bottom-width: 0;
+        border-top-width: 1px;
+    }
+
+    QTabWidget::pane {
+        padding: 0;
+        margin-top: 0;
+    }
+"""
+
 
 class MyQLabel(QLabel):
     def __init__(self, parent):

--- a/riocore/widgets.py
+++ b/riocore/widgets.py
@@ -37,25 +37,27 @@ STYLESHEET_CHECKBOX_GREEN_RED = """
 
 # MacOS tabs default to white backgrounds, making them unreadable without more styling. 
 STYLESHEET_TABBAR = """
+    QTabWidget::tab-bar {
+        left: 0;
+    }
+
     QTabBar::tab {
         background-color: #333333;
-        border-style: solid;
-        border-color: #222222;
-        border-width: 2px 1px 0px;
+        border: 1px solid #222222;
         color: white;
         padding: 5px 10px;
-        margin: 5px 1px 0px;
     }
 
     QTabBar::tab:selected {
         background-color: #444444;
-        border-bottom-width: 0;
-        border-top-width: 1px;
+        border-bottom-color: #444444;
     }
 
     QTabWidget::pane {
-        padding: 0;
+        top: -1px;
         margin-top: 0;
+        padding: 10px;
+        border: 1px solid black;
     }
 """
 


### PR DESCRIPTION
By default, MacOS gives tabs in a tab bar a white background. This makes the white text of the labels invisible. I have added some stylesheets to explicitly set the styling of tabs (on all platforms).

It's my first time messing with QT5, so I'm not sure how well I've done this. Happy for feedback; hopeful this is useful to others.

### Tabs on MacOS before
<img width="602" alt="MacOS tabs" src="https://github.com/user-attachments/assets/17aa71a1-1b74-49c7-9645-84d5a27839bb" />

### Tabs on MacOS after
<img width="568" alt="image" src="https://github.com/user-attachments/assets/975050e6-6349-4fcf-a431-9323968a39df" />

Despite spending hours fighting VMs, I'm currently unable to test this change on other systems. Sorry about that, I'd've liked to show more examples!