### PR TITLE
generator fixes

### DIFF
--- a/riocore/plugins/fpga/generator/cclient.py
+++ b/riocore/plugins/fpga/generator/cclient.py
@@ -112,10 +112,12 @@ class cclient(generator_base):
         output.append("#include <riocore.h>")
         output.append("")
 
-        buffer_size_bytes = self.project.buffer_size // 8
-        buffer_init = ["0"] * buffer_size_bytes
-        output.append(f"uint8_t rxBuffer[BUFFER_SIZE_RX] = {{{', '.join(buffer_init)}}};")
-        output.append(f"uint8_t txBuffer[BUFFER_SIZE_TX] = {{{', '.join(buffer_init)}}};")
+        rx_buffer_size_bytes = self.buffer_size_out // 8
+        tx_buffer_size_bytes = self.buffer_size_in // 8
+        rx_buffer_init = ["0"] * rx_buffer_size_bytes
+        tx_buffer_init = ["0"] * tx_buffer_size_bytes
+        output.append(f"uint8_t rxBuffer[BUFFER_SIZE_RX] = {{{', '.join(rx_buffer_init)}}};")
+        output.append(f"uint8_t txBuffer[BUFFER_SIZE_TX] = {{{', '.join(tx_buffer_init)}}};")
 
         if self.multiplexed_output:
             output.append("float MULTIPLEXER_INPUT_VALUE;")

--- a/riocore/plugins/fpga/generator/jslib.py
+++ b/riocore/plugins/fpga/generator/jslib.py
@@ -238,7 +238,7 @@ class jslib(generator_base):
         if not http_support:
             for plugin, values in self.rx_dict.items():
                 for key, value in values.items():
-                    output.append(f'    console.log("{plugin}.{key} = ", rio_rx["{plugin}"]["{key}"]);')
+                    output.append(f'    console.log("{plugin}.{key} = ", rio_rx["{plugin}"] ? rio_rx["{plugin}"]["{key}"] : "N/A");')
         output.append("});")
         output.append("")
         output.append("function send() {")
@@ -296,7 +296,7 @@ class jslib(generator_base):
             for plugin, values in self.rx_dict.items():
                 for key, value in values.items():
                     output.append(f'    res.write("{plugin}.{key} = ");')
-                    output.append(f'    res.write(String(rio_rx["{plugin}"]["{key}"]));')
+                    output.append(f'    res.write(String(rio_rx["{plugin}"] ? rio_rx["{plugin}"]["{key}"] : "N/A"));')
                     output.append('    res.write("<br/>");')
             output.append("")
             output.append("    res.end();")

--- a/riocore/plugins/fpga/generator/simulator.py
+++ b/riocore/plugins/fpga/generator/simulator.py
@@ -475,7 +475,7 @@ class simulator(generator_base):
         output.append("void* simThread(void* vargp) {")
         output.append("    uint16_t ret = 0;")
         output.append("")
-        output.append("    interface_init(0, NULL);")
+        output.append("    interface_init();")
         output.append("")
         output.append("    modbus_init();")
         output.append("")


### PR DESCRIPTION
riocore/plugins/fpga/generator/simulator.py
Changed generated call from interfaceinit(0, NULL); to interfaceinit(); The generated interface_init() function takes no arguments, so the two arguments caused a compile error.

riocore/plugins/fpga/generator/cclient.py
Fixed rxBuffer/txBuffer initializers to use their respective buffer sizes. Previously both arrays were initialized with self.project.buffersize // 8 zeros, but BUFFERSIZERX and BUFFERSIZE_TX can differ (here 49 vs 70 bytes), producing "excess elements in array initializer" warnings for the smaller array.

Fixed the JSLIB crash in the generator and regenerated client.js.
Root cause: rio_rx starts as {} and is only populated after the first UDP packet arrives. If the HTTP server is hit before that, rio_rx["mbus0"] is undefined, so rio_rx["mbus0"]["rxdata"] throws TypeError.